### PR TITLE
Make openssl dependency optional

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,8 @@ vsftpd_group: ftp
 vsftpd_service_enabled: yes
 # current state: started, stopped
 vsftpd_service_state: started
+# enable ssl by default
+vsftpd_enable_ssl: true
 # default ssl key
 vsftpd_key_file: ssl-cert-snakeoil.key
 # default ssl cert

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -142,4 +142,10 @@ galaxy_info:
 # Be sure to remove the '[]' above if you add dependencies
 # to this list.
 dependencies:
-  - weareinteractive.openssl
+  - role: weareinteractive.openssl
+    when:
+      - vsftpd_enable_ssl|default(true)
+    tags:
+      - ssl-dependency
+      - dependencies
+      - openssl

--- a/templates/etc/vsftpd.conf.j2
+++ b/templates/etc/vsftpd.conf.j2
@@ -143,12 +143,14 @@ connect_from_port_20=YES
 # This string is the name of the PAM service vsftpd will use.
 pam_service_name=vsftpd
 #
+{% if vsftpd_enable_ssl %}
 # This option specifies the location of the RSA certificate to use for SSL
 # encrypted connections.
 rsa_cert_file={{ openssl_certs_path }}/{{ vsftpd_cert_file }}
 # This option specifies the location of the RSA key to use for SSL
 # encrypted connections.
 rsa_private_key_file={{ openssl_keys_path }}/{{ vsftpd_key_file }}
+{% endif %}
 
 {% for key, value in vsftpd_config.items() %}
 {{ key }}={{ {true: "YES", false: "NO"}[value] | default(value) }}


### PR DESCRIPTION
Default behavior is unchanged. Other roles dependent on this role will have several options to skip the openssl dependency.

```
--skip-tags=ssl-dependency 
```
or
```
vsftpd_enable_ssl: false
```